### PR TITLE
Revert URL launcher work for macOS

### DIFF
--- a/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import url_launcher_fde
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/gallery/pubspec.lock
+++ b/gallery/pubspec.lock
@@ -322,15 +322,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.2.5"
-  url_launcher_fde:
-    dependency: "direct main"
-    description:
-      path: "plugins/flutter_plugins/url_launcher_fde"
-      ref: a075c245ffdfc17409a3fff12517cf416aa77c87
-      resolved-ref: a075c245ffdfc17409a3fff12517cf416aa77c87
-      url: "git://github.com/google/flutter-desktop-embedding.git"
-    source: git
-    version: "0.0.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/gallery/pubspec.yaml
+++ b/gallery/pubspec.yaml
@@ -20,11 +20,11 @@ dependencies:
   shrine_images: ^1.1.2
   flare_flutter: ^1.6.5
   url_launcher:
-  url_launcher_fde:
-    git:
-      url: git://github.com/google/flutter-desktop-embedding.git
-      ref: a075c245ffdfc17409a3fff12517cf416aa77c87
-      path: plugins/flutter_plugins/url_launcher_fde
+#  url_launcher_fde:
+#    git:
+#      url: git://github.com/google/flutter-desktop-embedding.git
+#      ref: a075c245ffdfc17409a3fff12517cf416aa77c87
+#      path: plugins/flutter_plugins/url_launcher_fde
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Revert of https://github.com/material-components/material-components-flutter-gallery/pull/294

This PR was causing the deployed web app to not work at all.

## Related Issues

Reopens #159 
